### PR TITLE
GH Release Actions

### DIFF
--- a/.github/workflows/kibot-commit-check.yaml
+++ b/.github/workflows/kibot-commit-check.yaml
@@ -1,0 +1,17 @@
+name: CI
+
+on: [push]
+
+jobs:
+  erc-drc-checks:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: INTI-CMNB/KiBot@v2_k6
+        with:
+          config: PCB/xESC2040/xESC2.kibot.yaml
+          board: PCB/xESC2040/xESC2.kicad_pcb
+          verbose: 1

--- a/.github/workflows/kibot-release-from-tag.yaml
+++ b/.github/workflows/kibot-release-from-tag.yaml
@@ -1,0 +1,48 @@
+name: tagged-release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  tagged-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: INTI-CMNB/KiBot@v2_k6
+        with:
+          config: PCB/xESC2040/xESC2.kibot.yaml
+          board: PCB/xESC2040/xESC2.kicad_pcb
+          skip: run_drc,run_erc
+
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: false
+          files: release/*
+
+      - name: Deploy release
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: release
+          destination_dir: release
+
+      - name: Deploy release_navigator
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: release_navigator
+          destination_dir: release_navigator
+          keep_files: true
+
+      - name: Deploy release_navigator index
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: release_navigator
+          keep_files: true

--- a/PCB/xESC2040/.gitignore
+++ b/PCB/xESC2040/.gitignore
@@ -31,3 +31,6 @@ fp-info-cache
 replicate_layout.log
 
 MyModules3d/
+
+release
+release_navigator

--- a/PCB/xESC2040/xESC2.kibot.yaml
+++ b/PCB/xESC2040/xESC2.kibot.yaml
@@ -1,0 +1,82 @@
+kibot:
+  version: 1
+
+preflight:
+  run_erc: true
+  run_drc: true
+  set_text_variables:
+    - name: 'git_version'
+      command: 'git describe --tags'
+
+outputs:
+  - name: 'bom'
+    type: 'bom'
+    dir: 'release'
+
+  - name: 'write_gerber_drill'
+    comment: 'This is the information for the drilling machine in gerber format.'
+    type: 'gerb_drill'
+    dir: 'release/gerber'
+
+  - name: 'write_gerber'
+    comment: 'This is the main fabrication format for the PCB.'
+    type: 'gerber'
+    dir: 'release/gerber'
+    layers: 'selected'
+
+  - name: 'gerber'
+    comment: 'Generates a compressed file containing gerber files.'
+    type: 'compress'
+    dir: 'release'
+    options:
+      files:
+        # [string=''] Destination directory inside the archive, empty means the same of the file
+        - dest: '.'
+          source: 'release/gerber/*'
+
+  - name: 'position'
+    comment: 'Generates the file with position information for the PCB components, used by the pick and place machine.'
+    type: 'position'
+    dir: 'release'
+
+  - name: 'ibom'
+    comment: 'Generates an interactive web page useful to identify the position of the components in the PCB.'
+    type: 'ibom'
+    dir: 'release'
+
+  - name: 'pcbdraw_svg'
+    comment: 'Exports the PCB as a 2D model (SVG, PNG or JPG).'
+    type: 'pcbdraw'
+    dir: 'release'
+    options:
+      format: 'svg'
+
+  - name: 'pcbdraw_png'
+    comment: 'Exports the PCB as a 2D model (SVG, PNG or JPG).'
+    type: 'pcbdraw'
+    dir: 'release'
+    options:
+      format: 'png'
+
+  - name: 'pcbdraw_svg_bottom'
+    comment: 'Exports the PCB as a 2D model (SVG, PNG or JPG).'
+    type: 'pcbdraw'
+    dir: 'release'
+    options:
+      bottom: true
+      format: 'svg'
+
+  - name: 'pcbdraw_png_bottom'
+    comment: 'Exports the PCB as a 2D model (SVG, PNG or JPG).'
+    type: 'pcbdraw'
+    dir: 'release'
+    options:
+      bottom: true
+      format: 'png'
+
+  - name: 'navigate_results'
+    comment: 'Generates a web page to navigate the generated outputs'
+    type: 'navigate_results'
+    dir: 'release_navigator'
+    options:
+      link_from_root: "release_navigator/index.html"

--- a/PCB/xESC2040/xESC2.kicad_pcb
+++ b/PCB/xESC2040/xESC2.kicad_pcb
@@ -5220,7 +5220,7 @@
   (gr_line (start 278.5 103.9) (end 278.5 132.9) (layer "Edge.Cuts") (width 0.05) (tstamp 28d567f0-48d1-4c95-a0cb-a8a12c39cbbe))
   (gr_line (start 229 132.9) (end 229 103.9) (layer "Edge.Cuts") (width 0.05) (tstamp 813e9b58-e0a0-4d7c-846c-24730cf15af6))
   (gr_line (start 278.5 132.9) (end 229 132.9) (layer "Edge.Cuts") (width 0.05) (tstamp 87ba8cb9-dc95-4e5c-81f3-3c6d0f72e5ad))
-  (gr_text "xESC RP2040\nV1.01" (at 270.025 118.475 270) (layer "B.SilkS") (tstamp 68a99320-95a1-446a-a935-f7e0ec32cfc3)
+  (gr_text "xESC RP2040\n${git_version}" (at 270.025 118.475 270) (layer "B.SilkS") (tstamp 68a99320-95a1-446a-a935-f7e0ec32cfc3)
     (effects (font (size 1 0.9) (thickness 0.15)) (justify mirror))
   )
   (gr_text "USB\nBoot" (at 260.275 131.025) (layer "F.SilkS") (tstamp 9c040984-8776-48df-a703-16236ef2e087)

--- a/PCB/xESC2040/xESC2.kicad_pro
+++ b/PCB/xESC2040/xESC2.kicad_pro
@@ -488,5 +488,7 @@
       "CAN"
     ]
   ],
-  "text_variables": {}
+  "text_variables": {
+    "git_version": "WIP"
+  }
 }


### PR DESCRIPTION
Same as for main repo:
 - https://rfvermut.github.io/xESC/
 - https://github.com/rfvermut/xESC/releases/tag/v1.1.0

NB! Keep in mind that versioning need to be semantic. current `v1.01` won't work.